### PR TITLE
Improve universal call widget experience

### DIFF
--- a/universal-call-widget/index.html
+++ b/universal-call-widget/index.html
@@ -6,23 +6,60 @@
   <title>SignalWire Universal Call Widget</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:#f5f5f5; padding:20px; }
-    .container { max-width:1200px; margin:0 auto; background:white; border-radius:12px; box-shadow:0 2px 8px rgba(0,0,0,0.1); padding:30px; }
-    h1 { color:#333; margin-bottom:30px; text-align:center; }
+    body {
+      font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+      background:#000;
+      color:#eee;
+      padding:20px;
+    }
+    .container {
+      max-width:1200px;
+      margin:0 auto;
+      background:#111;
+      border-radius:12px;
+      box-shadow:0 2px 8px rgba(0,255,255,0.2);
+      padding:30px;
+    }
+    h1 { color:#0ff; margin-bottom:30px; text-align:center; }
     .controls { display:flex; gap:20px; margin-bottom:30px; flex-wrap:wrap; align-items:center; }
     .form-group { flex:1; min-width:250px; }
-    label { display:block; margin-bottom:5px; font-weight:500; color:#555; }
-    select { width:100%; padding:10px; border:1px solid #ddd; border-radius:6px; font-size:14px; }
+    label { display:block; margin-bottom:5px; font-weight:500; color:#bbb; }
+    select {
+      width:100%;
+      padding:10px;
+      border:1px solid #444;
+      background:#000;
+      color:#eee;
+      border-radius:6px;
+      font-size:14px;
+    }
     .checkbox-group { display:flex; gap:20px; align-items:center; }
     .checkbox-group label { display:flex; align-items:center; gap:5px; margin:0; }
-    button { padding:12px 24px; background:#007acc; color:white; border:none; border-radius:6px; cursor:pointer; font-size:16px; font-weight:500; transition:background 0.2s; }
-    button:hover { background:#005a9e; }
-    button:disabled { background:#ccc; cursor:not-allowed; }
-    .status { padding:20px; background:#f8f9fa; border-radius:8px; margin-bottom:20px; display:none; }
+    button {
+      padding:12px 24px;
+      background:#007acc;
+      color:#fff;
+      border:none;
+      border-radius:6px;
+      cursor:pointer;
+      font-size:16px;
+      font-weight:500;
+      transition:background 0.2s;
+    }
+    button:hover { background:#00aaff; }
+    button:disabled { background:#555; cursor:not-allowed; }
+    .status {
+      padding:20px;
+      background:#222;
+      border-radius:8px;
+      margin-bottom:20px;
+      display:none;
+      color:#eee;
+    }
     .status.show { display:block; }
-    .status.success { background:#d4edda; color:#155724; border:1px solid #c3e6cb; }
-    .status.error { background:#f8d7da; color:#721c24; border:1px solid #f5c6cb; }
-    .status.info { background:#d1ecf1; color:#0c5460; border:1px solid #bee5eb; }
+    .status.success { background:#155724; color:#a4f3a3; border:1px solid #28a745; }
+    .status.error { background:#721c24; color:#f5c6cb; border:1px solid #dc3545; }
+    .status.info { background:#0c5460; color:#bee5eb; border:1px solid #17a2b8; }
     #videoContainer { width:100%; min-height:600px; background:#000; border-radius:8px; position:relative; display:none; margin-bottom:20px; }
     #videoContainer.show { display:block; }
     #remoteVideo { width:100%; height:600px; background:#000; border-radius:8px; }
@@ -33,16 +70,29 @@
     .control-btn.mute { background:#6c757d; }
     .control-btn.unmute { background:#28a745; }
     .control-btn.end { background:#dc3545; }
-    .transcript { max-height:400px; overflow-y:auto; border:1px solid #ddd; border-radius:8px; padding:20px; background:#f8f9fa; }
-    .transcript-entry { margin-bottom:10px; padding:10px; border-radius:4px; background:#fff; color:#111; }
-    .transcript-entry.ai { border-left:4px solid #007acc; background:#e7f1ff; }
-    .transcript-entry.user { border-left:4px solid #28a745; background:#e8f5e9; }
-    .transcript-entry.system { border-left:4px solid #6c757d; background:#f0f0f0; font-style:italic; }
+    .transcript {
+      max-height:400px;
+      overflow-y:auto;
+      border:1px solid #444;
+      border-radius:8px;
+      padding:20px;
+      background:#222;
+    }
+    .transcript-entry {
+      margin-bottom:10px;
+      padding:10px;
+      border-radius:4px;
+      background:#111;
+      color:#eee;
+    }
+    .transcript-entry.ai { border-left:4px solid #0ff; background:#032333; }
+    .transcript-entry.user { border-left:4px solid #0f0; background:#013301; }
+    .transcript-entry.system { border-left:4px solid #888; background:#333; font-style:italic; }
     .transcript-entry.partial { opacity:0.7; }
-    .timestamp { font-size:12px; color:#666; margin-bottom:5px; }
+    .timestamp { font-size:12px; color:#999; margin-bottom:5px; }
     .quick-dial { display:flex; gap:10px; margin-bottom:20px; }
-    .quick-dial button { background:#28a745; }
-    .quick-dial button:hover { background:#218838; }
+    .quick-dial button { background:#28a745; color:#fff; }
+    .quick-dial button:hover { background:#3cdf5f; }
   </style>
 </head>
 <body>
@@ -138,20 +188,19 @@
         const select = document.getElementById('resourceSelect');
         select.innerHTML = '<option value="">Select a resource...</option>';
         if (data.success && data.resources) {
-          data.resources.forEach(resource => {
-            const option = document.createElement('option');
-            let address = resource.address || resource.id;
-            if (resource.type === 'swml_script' || resource.type === 'ai_agent') {
-              if (!address.startsWith('/')) address = `/private/${resource.display_name || resource.id}`;
-            }
-            option.value = address;
-            let emoji = '📹';
-            if (resource.type === 'swml_script') emoji = '🤖';
-            if (resource.type === 'ai_agent') emoji = '🧠';
-            if (resource.type === 'subscriber') emoji = '👤';
-            option.textContent = `${emoji} ${resource.display_name || resource.name || resource.id} (${resource.type})`;
-            select.appendChild(option);
-          });
+          data.resources
+            .filter(r => r.type === 'swml_script' || r.type === 'ai_agent')
+            .forEach(resource => {
+              const option = document.createElement('option');
+              let address = resource.address || resource.id;
+              if (!address.startsWith('/')) {
+                address = `/private/${resource.display_name || resource.id}`;
+              }
+              option.value = address;
+              let emoji = resource.type === 'swml_script' ? '🤖' : '🧠';
+              option.textContent = `${emoji} ${resource.display_name || resource.name || resource.id}`;
+              select.appendChild(option);
+            });
         }
       } catch (error) {
         console.error('Error loading resources:', error);
@@ -160,17 +209,20 @@
 
     function setupEventListeners() {
       if (!signalWireClient) return;
-      signalWireClient.on('ai.partial_result', (params) => addTranscript('ai', `AI (typing): ${params.text}`, 'partial'));
+      signalWireClient.on('ai.partial_result', (params) => {
+        finalizeUserSpeaking();
+        addTranscript('ai', `AI (typing): ${params.text}`, 'partial');
+      });
       signalWireClient.on('ai.speech_detect', (params) => {
         const cleanText = params.text.replace(/\{confidence=[\d.]+\}/, "");
-        addTranscript('user', `You: ${cleanText}`, 'complete');
+        updateUserSpeaking(cleanText);
       });
       signalWireClient.on('ai.completion', (params) => finalizeAiSpeaking(params.text));
       signalWireClient.on('ai.response_utterance', (params) => updateAiSpeaking(params.utterance));
     }
 
-    async function makeCall() {
-      const destination = document.getElementById('resourceSelect').value;
+    async function makeCall(dest) {
+      const destination = dest || document.getElementById('resourceSelect').value;
       if (!destination) { showStatus('Please select a resource to call', 'error'); return; }
       if (!signalWireClient) { showStatus('Client not initialized', 'error'); return; }
       try {
@@ -200,8 +252,15 @@
     }
 
     function quickDial(destination) {
-      document.getElementById('resourceSelect').value = destination;
-      makeCall();
+      const select = document.getElementById('resourceSelect');
+      if (!Array.from(select.options).some(opt => opt.value === destination)) {
+        const opt = document.createElement('option');
+        opt.value = destination;
+        opt.textContent = destination;
+        select.appendChild(opt);
+      }
+      select.value = destination;
+      makeCall(destination);
     }
 
     async function setupLocalVideo() {
@@ -243,11 +302,14 @@
       document.getElementById('callControls').classList.remove('show');
       document.getElementById('callButton').disabled = false;
       document.getElementById('localVideo').innerHTML = '';
+      finalizeUserSpeaking();
       showStatus('Call ended', 'info');
       addTranscript('system', 'Call ended', 'complete');
     }
 
     let aiSpeakingEntry = null;
+    let userSpeakingEntry = null;
+    let userSpeechTimeout = null;
 
     function addTranscript(type, text, status, returnEntry = false) {
       const content = document.getElementById('transcriptContent');
@@ -268,6 +330,7 @@
         const textDiv = aiSpeakingEntry.querySelector('.text');
         textDiv.textContent += ` ${text}`;
       }
+      scrollTranscript();
     }
 
     function finalizeAiSpeaking(finalText) {
@@ -279,6 +342,32 @@
       } else {
         addTranscript('ai', `AI: ${finalText}`, 'complete');
       }
+      scrollTranscript();
+    }
+
+    function updateUserSpeaking(text) {
+      if (!userSpeakingEntry) {
+        userSpeakingEntry = addTranscript('user', `You: ${text}`, 'partial', true);
+      } else {
+        const textDiv = userSpeakingEntry.querySelector('.text');
+        textDiv.textContent = `You: ${text}`;
+      }
+      scrollTranscript();
+      if (userSpeechTimeout) clearTimeout(userSpeechTimeout);
+      userSpeechTimeout = setTimeout(finalizeUserSpeaking, 1000);
+    }
+
+    function finalizeUserSpeaking() {
+      if (userSpeakingEntry) {
+        userSpeakingEntry.classList.remove('partial');
+        userSpeakingEntry = null;
+        scrollTranscript();
+      }
+    }
+
+    function scrollTranscript() {
+      const content = document.getElementById('transcriptContent');
+      content.scrollTop = content.scrollHeight;
     }
 
     function showStatus(message, type) {


### PR DESCRIPTION
## Summary
- update call widget colors for a darker futuristic style
- filter resources to only show SWML scripts and AI agents
- quick dial now calls destination directly and adds missing option
- consolidate user transcript bubbles and auto-scroll transcript
- ensure transcript scrolls with AI responses

## Testing
- `node verify-docs.js`


------
https://chatgpt.com/codex/tasks/task_e_688a510b2e588321a9d0cecee9b3ae74