### PR TITLE
Persist subscriber id across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,26 @@ When `receive-calls` is enabled:
   ></call-widget>
   ```
 
+### Reusing a Subscriber ID
+
+Each call to `/api/create-subscriber-token` returns a `subscriber_id`. Store this
+value client side and supply it in later token requests to maintain the same
+subscriber across sessions:
+
+```javascript
+const saved = localStorage.getItem('subscriber_id');
+const resp = await fetch('/api/create-subscriber-token', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    displayName: 'Universal Caller',
+    subscriberId: saved,
+  }),
+});
+const data = await resp.json();
+localStorage.setItem('subscriber_id', data.subscriber_id);
+```
+
 ## Running in Cursor
 
 To quickly test the sample server using the [Cursor](https://cursor.sh) IDE:

--- a/doc-for-c2c-widget/docs/_usage.mdx
+++ b/doc-for-c2c-widget/docs/_usage.mdx
@@ -394,6 +394,26 @@ When `receive-calls` is enabled:
   ></call-widget>
   ```
 
+### Reusing a Subscriber ID
+
+Each call to `/api/create-subscriber-token` returns a `subscriber_id`. Store this
+value client side and supply it in later token requests to maintain the same
+subscriber across sessions:
+
+```javascript
+const saved = localStorage.getItem('subscriber_id');
+const resp = await fetch('/api/create-subscriber-token', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    displayName: 'Universal Caller',
+    subscriberId: saved,
+  }),
+});
+const data = await resp.json();
+localStorage.setItem('subscriber_id', data.subscriber_id);
+```
+
 ## Running in Cursor
 
 To quickly test the sample server using the [Cursor](https://cursor.sh) IDE:

--- a/embed-script/README.md
+++ b/embed-script/README.md
@@ -394,6 +394,26 @@ When `receive-calls` is enabled:
   ></call-widget>
   ```
 
+### Reusing a Subscriber ID
+
+Each call to `/api/create-subscriber-token` returns a `subscriber_id`. Store this
+value client side and supply it in later token requests to maintain the same
+subscriber across sessions:
+
+```javascript
+const saved = localStorage.getItem('subscriber_id');
+const resp = await fetch('/api/create-subscriber-token', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    displayName: 'Universal Caller',
+    subscriberId: saved,
+  }),
+});
+const data = await resp.json();
+localStorage.setItem('subscriber_id', data.subscriber_id);
+```
+
 ## Running in Cursor
 
 To quickly test the sample server using the [Cursor](https://cursor.sh) IDE:

--- a/universal-call-widget/index.html
+++ b/universal-call-widget/index.html
@@ -152,10 +152,14 @@
 
     async function setupAuthentication() {
       try {
+        const storedId = localStorage.getItem('subscriber_id');
         const response = await fetch('/api/create-subscriber-token', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ displayName: 'Universal Caller' }),
+          body: JSON.stringify({
+            displayName: 'Universal Caller',
+            subscriberId: storedId,
+          }),
         });
 
         if (!response.ok) {
@@ -173,6 +177,9 @@
         }
 
         const data = await response.json();
+        if (data.subscriber_id) {
+          localStorage.setItem('subscriber_id', data.subscriber_id);
+        }
         signalWireClient = await SignalWire.SignalWire({ token: data.token, host: 'demo.signalwire.com' });
         setupEventListeners();
       } catch (error) {

--- a/universal-call-widget/server.js
+++ b/universal-call-widget/server.js
@@ -19,11 +19,12 @@ const SIGNALWIRE_CONFIG = {
 
 app.post('/api/create-subscriber-token', async (req, res) => {
   try {
-    const { displayName } = req.body;
-    const subscriberId = `video-caller-${Math.random().toString(36).substr(2, 9)}`;
+    const { displayName, subscriberId } = req.body;
+    const finalSubscriberId =
+      subscriberId || `video-caller-${Math.random().toString(36).substr(2, 9)}`;
 
     const requestBody = {
-      subscriber_id: subscriberId,
+      subscriber_id: finalSubscriberId,
       reference: `video-caller-${Date.now()}`,
       ttl: 3600,
     };
@@ -43,7 +44,7 @@ app.post('/api/create-subscriber-token', async (req, res) => {
     res.json({
       success: true,
       token: response.data.token,
-      subscriber_id: response.data.subscriber_id,
+      subscriber_id: finalSubscriberId,
       display_name: displayName,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- allow /api/create-subscriber-token to reuse a provided subscriberId
- persist subscriber_id in localStorage and reuse it when requesting tokens
- document how to reuse a subscriber ID across sessions

## Testing
- `node verify-docs.js`

------
https://chatgpt.com/codex/tasks/task_e_688a8ae55f2c8321943f329cb3c46a13