### PR TITLE
Fix transcript autoscroll and remove undefined captions

### DIFF
--- a/embed-script/src/ui/chat.ui.ts
+++ b/embed-script/src/ui/chat.ui.ts
@@ -8,12 +8,7 @@ export default function createChatUI(
   chatHistory: ChatEntry[],
   currentRoot: HTMLElement
 ) {
-  const SCROLL_THRESHOLD = 300;
-
-  const chatPanelScrolledToBottom =
-    currentRoot.scrollHeight - currentRoot.clientHeight <=
-    currentRoot.scrollTop + SCROLL_THRESHOLD;
-  const previousScrollTop = currentRoot.scrollTop;
+  // Always keep the latest message in view
 
   const converter = new showdown.Converter();
   converter.setOption("openLinksInNewWindow", true);
@@ -44,12 +39,8 @@ export default function createChatUI(
     currentRoot.appendChild(chatContainer);
   }
 
-  if (chatPanelScrolledToBottom) {
-    currentRoot.scrollTo({
-      top: currentRoot.scrollHeight,
-      behavior: "smooth",
-    });
-  } else {
-    currentRoot.scrollTop = previousScrollTop;
-  }
+  currentRoot.scrollTo({
+    top: currentRoot.scrollHeight,
+    behavior: "smooth",
+  });
 }

--- a/universal-call-widget/index.html
+++ b/universal-call-widget/index.html
@@ -326,6 +326,7 @@
     }
 
     function updateAiSpeaking(text) {
+      if (!text) return;
       if (!aiSpeakingEntry) {
         aiSpeakingEntry = addTranscript('ai', `AI (speaking): ${text}`, 'partial', true);
       } else {


### PR DESCRIPTION
## Summary
- Ensure chat transcript scrolls to newest message
- Ignore empty AI utterances to prevent `undefined` captions

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ffdebfeb4832188cca768d48470f3